### PR TITLE
Always do batch send and supply amountsAdded param in FundingAdded event

### DIFF
--- a/contracts/FixedProductMarketMaker.sol
+++ b/contracts/FixedProductMarketMaker.sol
@@ -152,7 +152,7 @@ contract FixedProductMarketMaker is ERC20, ERC1155TokenReceiver {
         require(collateralToken.approve(address(conditionalTokens), addedFunds), "approval for splits failed");
         splitPositionThroughAllConditions(addedFunds);
 
-        uint[] memory sendBackAmounts = new uint[](0);
+        uint[] memory sendBackAmounts = new uint[](positionIds.length);
         uint poolShareSupply = totalSupply();
         uint mintAmount;
         if(poolShareSupply > 0) {
@@ -165,8 +165,6 @@ contract FixedProductMarketMaker is ERC20, ERC1155TokenReceiver {
                 if(maxBalance < balance)
                     maxBalance = balance;
             }
-
-            sendBackAmounts = new uint[](poolBalances.length);
 
             for(uint i = 0; i < poolBalances.length; i++) {
                 uint remaining = addedFunds.mul(poolBalances[i]) / maxBalance;
@@ -184,8 +182,6 @@ contract FixedProductMarketMaker is ERC20, ERC1155TokenReceiver {
                         maxHint = hint;
                 }
 
-                sendBackAmounts = new uint[](distributionHint.length);
-
                 for(uint i = 0; i < distributionHint.length; i++) {
                     uint remaining = addedFunds.mul(distributionHint[i]) / maxHint;
                     require(remaining > 0, "must hint a valid distribution");
@@ -197,8 +193,8 @@ contract FixedProductMarketMaker is ERC20, ERC1155TokenReceiver {
         }
 
         _mint(msg.sender, mintAmount);
-        if(sendBackAmounts.length == positionIds.length)
-            conditionalTokens.safeBatchTransferFrom(address(this), msg.sender, positionIds, sendBackAmounts, "");
+
+        conditionalTokens.safeBatchTransferFrom(address(this), msg.sender, positionIds, sendBackAmounts, "");
 
         // transform sendBackAmounts to array of amounts added
         for (uint i = 0; i < sendBackAmounts.length; i++) {


### PR DESCRIPTION
Before this, an empty `distributionHint` would cause `addFunding` to skip the batch transfer after the split and fire a `FundingAdded` event with an empty `amountsAdded` param. This PR ensures that:

* Batch transfer of conditional tokens happen always even if it would be with all zero amounts. I thought about skipping this, but before, the behavior was that if the distribution hint ended up like the empty distributionHint case where there would be no conditional tokens sent back, the batch transfer of all zeros would execute anyway, making the behavior subtly different between the two cases. An alternative would be to filter out zero amounts and skip the call if everything was filtered out, but this is simpler code to read/write.
* The `FundingAdded` always returns a correct `amountsAdded` param. Consumers of this event (in particular the code for subgraphs) would be able to expect more consistent data this way.