### PR TITLE
Fee pool proportion griefing mitigation

### DIFF
--- a/contracts/ERC20.sol
+++ b/contracts/ERC20.sol
@@ -1,0 +1,252 @@
+// This is a backported hooked OpenZeppelin ERC 20 implementation
+pragma solidity ^0.5.0;
+
+import { IERC20 } from "openzeppelin-solidity/contracts/token/ERC20/IERC20.sol";
+import { SafeMath } from "openzeppelin-solidity/contracts/math/SafeMath.sol";
+
+/**
+ * @dev Implementation of the {IERC20} interface.
+ *
+ * This implementation is agnostic to the way tokens are created. This means
+ * that a supply mechanism has to be added in a derived contract using {_mint}.
+ * For a generic mechanism see {ERC20Mintable}.
+ *
+ * TIP: For a detailed writeup see our guide
+ * https://forum.zeppelin.solutions/t/how-to-implement-erc20-supply-mechanisms/226[How
+ * to implement supply mechanisms].
+ *
+ * We have followed general OpenZeppelin guidelines: functions revert instead
+ * of returning `false` on failure. This behavior is nonetheless conventional
+ * and does not conflict with the expectations of ERC20 applications.
+ *
+ * Additionally, an {Approval} event is emitted on calls to {transferFrom}.
+ * This allows applications to reconstruct the allowance for all accounts just
+ * by listening to said events. Other implementations of the EIP may not emit
+ * these events, as it isn't required by the specification.
+ *
+ * Finally, the non-standard {decreaseAllowance} and {increaseAllowance}
+ * functions have been added to mitigate the well-known issues around setting
+ * allowances. See {IERC20-approve}.
+ */
+contract ERC20 is IERC20 {
+    using SafeMath for uint256;
+
+    mapping (address => uint256) private _balances;
+
+    mapping (address => mapping (address => uint256)) private _allowances;
+
+    uint256 private _totalSupply;
+
+    /**
+     * @dev See {IERC20-totalSupply}.
+     */
+    function totalSupply() public view returns (uint256) {
+        return _totalSupply;
+    }
+
+    /**
+     * @dev See {IERC20-balanceOf}.
+     */
+    function balanceOf(address account) public view returns (uint256) {
+        return _balances[account];
+    }
+
+    /**
+     * @dev See {IERC20-transfer}.
+     *
+     * Requirements:
+     *
+     * - `recipient` cannot be the zero address.
+     * - the caller must have a balance of at least `amount`.
+     */
+    function transfer(address recipient, uint256 amount) public returns (bool) {
+        _transfer(msg.sender, recipient, amount);
+        return true;
+    }
+
+    /**
+     * @dev See {IERC20-allowance}.
+     */
+    function allowance(address owner, address spender) public view returns (uint256) {
+        return _allowances[owner][spender];
+    }
+
+    /**
+     * @dev See {IERC20-approve}.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     */
+    function approve(address spender, uint256 amount) public returns (bool) {
+        _approve(msg.sender, spender, amount);
+        return true;
+    }
+
+    /**
+     * @dev See {IERC20-transferFrom}.
+     *
+     * Emits an {Approval} event indicating the updated allowance. This is not
+     * required by the EIP. See the note at the beginning of {ERC20};
+     *
+     * Requirements:
+     * - `sender` and `recipient` cannot be the zero address.
+     * - `sender` must have a balance of at least `amount`.
+     * - the caller must have allowance for `sender`'s tokens of at least
+     * `amount`.
+     */
+    function transferFrom(address sender, address recipient, uint256 amount) public returns (bool) {
+        _transfer(sender, recipient, amount);
+        _approve(sender, msg.sender, _allowances[sender][msg.sender].sub(amount));
+        return true;
+    }
+
+    /**
+     * @dev Atomically increases the allowance granted to `spender` by the caller.
+     *
+     * This is an alternative to {approve} that can be used as a mitigation for
+     * problems described in {IERC20-approve}.
+     *
+     * Emits an {Approval} event indicating the updated allowance.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     */
+    function increaseAllowance(address spender, uint256 addedValue) public returns (bool) {
+        _approve(msg.sender, spender, _allowances[msg.sender][spender].add(addedValue));
+        return true;
+    }
+
+    /**
+     * @dev Atomically decreases the allowance granted to `spender` by the caller.
+     *
+     * This is an alternative to {approve} that can be used as a mitigation for
+     * problems described in {IERC20-approve}.
+     *
+     * Emits an {Approval} event indicating the updated allowance.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     * - `spender` must have allowance for the caller of at least
+     * `subtractedValue`.
+     */
+    function decreaseAllowance(address spender, uint256 subtractedValue) public returns (bool) {
+        _approve(msg.sender, spender, _allowances[msg.sender][spender].sub(subtractedValue));
+        return true;
+    }
+
+    /**
+     * @dev Moves tokens `amount` from `sender` to `recipient`.
+     *
+     * This is internal function is equivalent to {transfer}, and can be used to
+     * e.g. implement automatic token fees, slashing mechanisms, etc.
+     *
+     * Emits a {Transfer} event.
+     *
+     * Requirements:
+     *
+     * - `sender` cannot be the zero address.
+     * - `recipient` cannot be the zero address.
+     * - `sender` must have a balance of at least `amount`.
+     */
+    function _transfer(address sender, address recipient, uint256 amount) internal {
+        require(sender != address(0), "ERC20: transfer from the zero address");
+        require(recipient != address(0), "ERC20: transfer to the zero address");
+
+        _beforeTokenTransfer(sender, recipient, amount);
+
+        _balances[sender] = _balances[sender].sub(amount);
+        _balances[recipient] = _balances[recipient].add(amount);
+        emit Transfer(sender, recipient, amount);
+    }
+
+    /** @dev Creates `amount` tokens and assigns them to `account`, increasing
+     * the total supply.
+     *
+     * Emits a {Transfer} event with `from` set to the zero address.
+     *
+     * Requirements
+     *
+     * - `to` cannot be the zero address.
+     */
+    function _mint(address account, uint256 amount) internal {
+        require(account != address(0), "ERC20: mint to the zero address");
+
+        _beforeTokenTransfer(address(0), account, amount);
+
+        _totalSupply = _totalSupply.add(amount);
+        _balances[account] = _balances[account].add(amount);
+        emit Transfer(address(0), account, amount);
+    }
+
+    /**
+     * @dev Destroys `amount` tokens from `account`, reducing the
+     * total supply.
+     *
+     * Emits a {Transfer} event with `to` set to the zero address.
+     *
+     * Requirements
+     *
+     * - `account` cannot be the zero address.
+     * - `account` must have at least `amount` tokens.
+     */
+    function _burn(address account, uint256 amount) internal {
+        require(account != address(0), "ERC20: burn from the zero address");
+
+        _beforeTokenTransfer(account, address(0), amount);
+
+        _balances[account] = _balances[account].sub(amount);
+        _totalSupply = _totalSupply.sub(amount);
+        emit Transfer(account, address(0), amount);
+    }
+
+    /**
+     * @dev Sets `amount` as the allowance of `spender` over the `owner`s tokens.
+     *
+     * This is internal function is equivalent to `approve`, and can be used to
+     * e.g. set automatic allowances for certain subsystems, etc.
+     *
+     * Emits an {Approval} event.
+     *
+     * Requirements:
+     *
+     * - `owner` cannot be the zero address.
+     * - `spender` cannot be the zero address.
+     */
+    function _approve(address owner, address spender, uint256 amount) internal {
+        require(owner != address(0), "ERC20: approve from the zero address");
+        require(spender != address(0), "ERC20: approve to the zero address");
+
+        _allowances[owner][spender] = amount;
+        emit Approval(owner, spender, amount);
+    }
+
+    /**
+     * @dev Destroys `amount` tokens from `account`.`amount` is then deducted
+     * from the caller's allowance.
+     *
+     * See {_burn} and {_approve}.
+     */
+    function _burnFrom(address account, uint256 amount) internal {
+        _burn(account, amount);
+        _approve(account, msg.sender, _allowances[account][msg.sender].sub(amount));
+    }
+
+    /**
+     * @dev Hook that is called before any transfer of tokens. This includes
+     * minting and burning.
+     *
+     * Calling conditions:
+     *
+     * - when `from` and `to` are both non-zero, `amount` of `from`'s tokens
+     * will be to transferred to `to`.
+     * - when `from` is zero, `amount` tokens will be minted for `to`.
+     * - when `to` is zero, `amount` of `from`'s tokens will be burned.
+     * - `from` and `to` are never both zero.
+     *
+     * To learn more about hooks, head to xref:ROOT:using-hooks.adoc[Using Hooks].
+     */
+    function _beforeTokenTransfer(address from, address to, uint256 amount) internal { }
+}

--- a/contracts/FPMMDeterministicFactory.sol
+++ b/contracts/FPMMDeterministicFactory.sol
@@ -20,7 +20,6 @@ contract FixedProductMarketMakerData {
     event FPMMFundingAdded(
         address indexed funder,
         uint[] amountsAdded,
-        uint collateralAddedToFeePool,
         uint sharesMinted
     );
     event FPMMFundingRemoved(
@@ -52,6 +51,8 @@ contract FixedProductMarketMakerData {
     uint[] internal outcomeSlotCounts;
     bytes32[][] internal collectionIds;
     uint[] internal positionIds;
+    mapping (address => uint256) internal withdrawnFees;
+    uint internal totalWithdrawnFees;
 }
 
 contract FPMMDeterministicFactory is Create2CloneFactory, FixedProductMarketMakerData, ERC1155TokenReceiver {

--- a/contracts/FPMMDeterministicFactory.sol
+++ b/contracts/FPMMDeterministicFactory.sol
@@ -4,56 +4,9 @@ import { IERC20 } from "openzeppelin-solidity/contracts/token/ERC20/IERC20.sol";
 import { ConditionalTokens } from "@gnosis.pm/conditional-tokens-contracts/contracts/ConditionalTokens.sol";
 import { CTHelpers } from "@gnosis.pm/conditional-tokens-contracts/contracts/CTHelpers.sol";
 import { Create2CloneFactory } from "./Create2CloneFactory.sol";
-import { FixedProductMarketMaker } from "./FixedProductMarketMaker.sol";
+import { FixedProductMarketMaker, FixedProductMarketMakerData } from "./FixedProductMarketMaker.sol";
 import { ERC1155TokenReceiver } from "@gnosis.pm/conditional-tokens-contracts/contracts/ERC1155/ERC1155TokenReceiver.sol";
 
-contract FixedProductMarketMakerData {
-    mapping (address => uint256) internal _balances;
-    mapping (address => mapping (address => uint256)) internal _allowances;
-    uint256 internal _totalSupply;
-
-
-    bytes4 internal constant _INTERFACE_ID_ERC165 = 0x01ffc9a7;
-    mapping(bytes4 => bool) internal _supportedInterfaces;
-
-
-    event FPMMFundingAdded(
-        address indexed funder,
-        uint[] amountsAdded,
-        uint sharesMinted
-    );
-    event FPMMFundingRemoved(
-        address indexed funder,
-        uint[] amountsRemoved,
-        uint collateralRemovedFromFeePool,
-        uint sharesBurnt
-    );
-    event FPMMBuy(
-        address indexed buyer,
-        uint investmentAmount,
-        uint feeAmount,
-        uint indexed outcomeIndex,
-        uint outcomeTokensBought
-    );
-    event FPMMSell(
-        address indexed seller,
-        uint returnAmount,
-        uint feeAmount,
-        uint indexed outcomeIndex,
-        uint outcomeTokensSold
-    );
-    ConditionalTokens internal conditionalTokens;
-    IERC20 internal collateralToken;
-    bytes32[] internal conditionIds;
-    uint internal fee;
-    uint internal collectedFees;
-
-    uint[] internal outcomeSlotCounts;
-    bytes32[][] internal collectionIds;
-    uint[] internal positionIds;
-    mapping (address => uint256) internal withdrawnFees;
-    uint internal totalWithdrawnFees;
-}
 
 contract FPMMDeterministicFactory is Create2CloneFactory, FixedProductMarketMakerData, ERC1155TokenReceiver {
     event FixedProductMarketMakerCreation(

--- a/contracts/FPMMDeterministicFactory.sol
+++ b/contracts/FPMMDeterministicFactory.sol
@@ -47,6 +47,7 @@ contract FixedProductMarketMakerData {
     IERC20 internal collateralToken;
     bytes32[] internal conditionIds;
     uint internal fee;
+    uint internal collectedFees;
 
     uint[] internal outcomeSlotCounts;
     bytes32[][] internal collectionIds;

--- a/contracts/FixedProductMarketMaker.sol
+++ b/contracts/FixedProductMarketMaker.sol
@@ -2,10 +2,10 @@ pragma solidity ^0.5.1;
 
 import { SafeMath } from "openzeppelin-solidity/contracts/math/SafeMath.sol";
 import { IERC20 } from "openzeppelin-solidity/contracts/token/ERC20/IERC20.sol";
-import { ERC20 } from "openzeppelin-solidity/contracts/token/ERC20/ERC20.sol";
 import { ConditionalTokens } from "@gnosis.pm/conditional-tokens-contracts/contracts/ConditionalTokens.sol";
 import { CTHelpers } from "@gnosis.pm/conditional-tokens-contracts/contracts/CTHelpers.sol";
 import { ERC1155TokenReceiver } from "@gnosis.pm/conditional-tokens-contracts/contracts/ERC1155/ERC1155TokenReceiver.sol";
+import { ERC20 } from "./ERC20.sol";
 
 
 library CeilDiv {
@@ -21,7 +21,6 @@ contract FixedProductMarketMaker is ERC20, ERC1155TokenReceiver {
     event FPMMFundingAdded(
         address indexed funder,
         uint[] amountsAdded,
-        uint collateralAddedToFeePool,
         uint sharesMinted
     );
     event FPMMFundingRemoved(
@@ -54,59 +53,13 @@ contract FixedProductMarketMaker is ERC20, ERC1155TokenReceiver {
     IERC20 public collateralToken;
     bytes32[] public conditionIds;
     uint public fee;
-    uint public collectedFees;
+    uint internal feePoolWeight;
 
     uint[] outcomeSlotCounts;
     bytes32[][] collectionIds;
     uint[] positionIds;
-
-    // constructor(
-    //     ConditionalTokens _conditionalTokens,
-    //     IERC20 _collateralToken,
-    //     bytes32[] memory _conditionIds,
-    //     uint _fee
-    // ) public {
-    //     conditionalTokens = _conditionalTokens;
-    //     collateralToken = _collateralToken;
-    //     conditionIds = _conditionIds;
-    //     fee = _fee;
-
-    //     uint atomicOutcomeSlotCount = 1;
-    //     outcomeSlotCounts = new uint[](conditionIds.length);
-    //     for (uint i = 0; i < conditionIds.length; i++) {
-    //         uint outcomeSlotCount = conditionalTokens.getOutcomeSlotCount(conditionIds[i]);
-    //         atomicOutcomeSlotCount *= outcomeSlotCount;
-    //         outcomeSlotCounts[i] = outcomeSlotCount;
-    //     }
-    //     require(atomicOutcomeSlotCount > 1, "conditions must be valid");
-
-    //     collectionIds = new bytes32[][](conditionIds.length);
-    //     _recordCollectionIDsForAllConditions(conditionIds.length, bytes32(0));
-    //     require(positionIds.length == atomicOutcomeSlotCount, "position IDs construction failed!?");
-    // }
-
-    // function _recordCollectionIDsForAllConditions(uint conditionsLeft, bytes32 parentCollectionId) private {
-    //     if(conditionsLeft == 0) {
-    //         positionIds.push(CTHelpers.getPositionId(collateralToken, parentCollectionId));
-    //         return;
-    //     }
-
-    //     conditionsLeft--;
-
-    //     uint outcomeSlotCount = outcomeSlotCounts[conditionsLeft];
-
-    //     collectionIds[conditionsLeft].push(parentCollectionId);
-    //     for(uint i = 0; i < outcomeSlotCount; i++) {
-    //         _recordCollectionIDsForAllConditions(
-    //             conditionsLeft,
-    //             CTHelpers.getCollectionId(
-    //                 parentCollectionId,
-    //                 conditionIds[conditionsLeft],
-    //                 1 << i
-    //             )
-    //         );
-    //     }
-    // }
+    mapping (address => uint256) withdrawnFees;
+    uint internal totalWithdrawnFees;
 
     function getPoolBalances() private view returns (uint[] memory) {
         address[] memory thises = new address[](positionIds.length);
@@ -149,13 +102,61 @@ contract FixedProductMarketMaker is ERC20, ERC1155TokenReceiver {
         }
     }
 
+    function collectedFees() external view returns (uint) {
+        return feePoolWeight.sub(totalWithdrawnFees);
+    }
+
+    function feesWithdrawableBy(address account) public view returns (uint) {
+        uint rawAmount = feePoolWeight.mul(balanceOf(account)) / totalSupply();
+        return rawAmount.sub(withdrawnFees[account]);
+    }
+
+    function withdrawFees() public {
+        uint rawAmount = feePoolWeight.mul(balanceOf(msg.sender)) / totalSupply();
+        uint withdrawableAmount = rawAmount.sub(withdrawnFees[msg.sender]);
+        if(withdrawableAmount > 0) {
+            withdrawnFees[msg.sender] = rawAmount;
+            require(
+                collateralToken.transfer(msg.sender, withdrawableAmount),
+                "withdrawal transfer failed"
+            );
+        }
+    }
+
+    function _beforeTokenTransfer(address from, address to, uint256 amount) internal {
+        uint withdrawnFeesTransfer;
+
+        if(from != address(0)) {
+            withdrawnFeesTransfer = withdrawnFees[from].mul(amount) / balanceOf(from);
+            withdrawnFees[from] = withdrawnFees[from].sub(withdrawnFeesTransfer);
+            totalWithdrawnFees = totalWithdrawnFees.sub(withdrawnFeesTransfer);
+        } else {
+            uint poolSupply = totalSupply();
+            if(poolSupply > 0) {
+                withdrawnFeesTransfer = feePoolWeight.mul(amount) / poolSupply;
+                feePoolWeight = feePoolWeight.add(withdrawnFeesTransfer);
+            }
+        }
+
+        if(to != address(0)) {
+            withdrawnFees[to] = withdrawnFees[to].add(withdrawnFeesTransfer);
+            totalWithdrawnFees = totalWithdrawnFees.add(withdrawnFeesTransfer);
+        } else {
+            uint rawAmount = (feePoolWeight.mul(amount) / totalSupply());
+            require(
+                collateralToken.transfer(from, rawAmount.sub(withdrawnFeesTransfer)),
+                "burn-triggered withdrawal failed"
+            );
+            feePoolWeight = feePoolWeight.sub(rawAmount);
+        }
+    }
+
     function addFunding(uint addedFunds, uint[] calldata distributionHint)
         external
     {
         require(addedFunds > 0, "funding must be non-zero");
 
         uint[] memory sendBackAmounts = new uint[](positionIds.length);
-        uint collateralAddedToFeePool;
         uint poolShareSupply = totalSupply();
         uint mintAmount;
         if(poolShareSupply > 0) {
@@ -168,13 +169,9 @@ contract FixedProductMarketMaker is ERC20, ERC1155TokenReceiver {
                     poolWeight = balance;
             }
 
-            poolWeight = poolWeight.add(collectedFees);
-
-            collateralAddedToFeePool = addedFunds.mul(collectedFees).ceildiv(poolWeight);
-
             for(uint i = 0; i < poolBalances.length; i++) {
                 uint remaining = addedFunds.mul(poolBalances[i]) / poolWeight;
-                sendBackAmounts[i] = addedFunds.sub(collateralAddedToFeePool).sub(remaining);
+                sendBackAmounts[i] = addedFunds.sub(remaining);
             }
 
             mintAmount = addedFunds.mul(poolShareSupply) / poolWeight;
@@ -199,10 +196,8 @@ contract FixedProductMarketMaker is ERC20, ERC1155TokenReceiver {
         }
 
         require(collateralToken.transferFrom(msg.sender, address(this), addedFunds), "funding transfer failed");
-        collectedFees = collectedFees.add(collateralAddedToFeePool);
-        uint collateralToSplit = addedFunds.sub(collateralAddedToFeePool);
-        require(collateralToken.approve(address(conditionalTokens), collateralToSplit), "approval for splits failed");
-        splitPositionThroughAllConditions(collateralToSplit);
+        require(collateralToken.approve(address(conditionalTokens), addedFunds), "approval for splits failed");
+        splitPositionThroughAllConditions(addedFunds);
 
         _mint(msg.sender, mintAmount);
 
@@ -213,7 +208,7 @@ contract FixedProductMarketMaker is ERC20, ERC1155TokenReceiver {
             sendBackAmounts[i] = addedFunds.sub(sendBackAmounts[i]);
         }
 
-        emit FPMMFundingAdded(msg.sender, sendBackAmounts, collateralAddedToFeePool, mintAmount);
+        emit FPMMFundingAdded(msg.sender, sendBackAmounts, mintAmount);
     }
 
     function removeFunding(uint sharesToBurn)
@@ -228,14 +223,13 @@ contract FixedProductMarketMaker is ERC20, ERC1155TokenReceiver {
             sendAmounts[i] = poolBalances[i].mul(sharesToBurn) / poolShareSupply;
         }
 
-        uint collateralRemovedFromFeePool = collectedFees.mul(sharesToBurn).ceildiv(poolShareSupply);
+        uint collateralRemovedFromFeePool = collateralToken.balanceOf(address(this));
 
         _burn(msg.sender, sharesToBurn);
-        require(
-            collateralToken.transfer(msg.sender, collateralRemovedFromFeePool),
-            "could not send share of collected fees to funder"
+        collateralRemovedFromFeePool = collateralRemovedFromFeePool.sub(
+            collateralToken.balanceOf(address(this))
         );
-        collectedFees = collectedFees.sub(collateralRemovedFromFeePool);
+
         conditionalTokens.safeBatchTransferFrom(address(this), msg.sender, positionIds, sendAmounts, "");
 
         emit FPMMFundingRemoved(msg.sender, sendAmounts, collateralRemovedFromFeePool, sharesToBurn);
@@ -320,7 +314,7 @@ contract FixedProductMarketMaker is ERC20, ERC1155TokenReceiver {
         require(collateralToken.transferFrom(msg.sender, address(this), investmentAmount), "cost transfer failed");
 
         uint feeAmount = investmentAmount.mul(fee) / ONE;
-        collectedFees = collectedFees.add(feeAmount);
+        feePoolWeight = feePoolWeight.add(feeAmount);
         uint investmentAmountMinusFees = investmentAmount.sub(feeAmount);
         require(collateralToken.approve(address(conditionalTokens), investmentAmountMinusFees), "approval for splits failed");
         splitPositionThroughAllConditions(investmentAmountMinusFees);
@@ -337,7 +331,7 @@ contract FixedProductMarketMaker is ERC20, ERC1155TokenReceiver {
         conditionalTokens.safeTransferFrom(msg.sender, address(this), positionIds[outcomeIndex], outcomeTokensToSell, "");
 
         uint feeAmount = returnAmount.mul(fee) / (ONE.sub(fee));
-        collectedFees = collectedFees.add(feeAmount);
+        feePoolWeight = feePoolWeight.add(feeAmount);
         uint returnAmountPlusFees = returnAmount.add(feeAmount);
         mergePositionsThroughAllConditions(returnAmountPlusFees);
 

--- a/contracts/FixedProductMarketMaker.sol
+++ b/contracts/FixedProductMarketMaker.sol
@@ -170,7 +170,7 @@ contract FixedProductMarketMaker is ERC20, ERC1155TokenReceiver {
 
             poolWeight = poolWeight.add(collectedFees);
 
-            collateralAddedToFeePool = addedFunds.mul(collectedFees) / poolWeight;
+            collateralAddedToFeePool = addedFunds.mul(collectedFees).ceildiv(poolWeight);
 
             for(uint i = 0; i < poolBalances.length; i++) {
                 uint remaining = addedFunds.mul(poolBalances[i]) / poolWeight;
@@ -228,7 +228,7 @@ contract FixedProductMarketMaker is ERC20, ERC1155TokenReceiver {
             sendAmounts[i] = poolBalances[i].mul(sharesToBurn) / poolShareSupply;
         }
 
-        uint collateralRemovedFromFeePool = collectedFees.mul(sharesToBurn) / poolShareSupply;
+        uint collateralRemovedFromFeePool = collectedFees.mul(sharesToBurn).ceildiv(poolShareSupply);
 
         _burn(msg.sender, sharesToBurn);
         require(

--- a/contracts/FixedProductMarketMaker.sol
+++ b/contracts/FixedProductMarketMaker.sol
@@ -334,3 +334,53 @@ contract FixedProductMarketMaker is ERC20, ERC1155TokenReceiver {
         emit FPMMSell(msg.sender, returnAmount, feeAmount, outcomeIndex, outcomeTokensToSell);
     }
 }
+
+
+// for proxying purposes
+contract FixedProductMarketMakerData {
+    mapping (address => uint256) internal _balances;
+    mapping (address => mapping (address => uint256)) internal _allowances;
+    uint256 internal _totalSupply;
+
+
+    bytes4 internal constant _INTERFACE_ID_ERC165 = 0x01ffc9a7;
+    mapping(bytes4 => bool) internal _supportedInterfaces;
+
+
+    event FPMMFundingAdded(
+        address indexed funder,
+        uint[] amountsAdded,
+        uint sharesMinted
+    );
+    event FPMMFundingRemoved(
+        address indexed funder,
+        uint[] amountsRemoved,
+        uint collateralRemovedFromFeePool,
+        uint sharesBurnt
+    );
+    event FPMMBuy(
+        address indexed buyer,
+        uint investmentAmount,
+        uint feeAmount,
+        uint indexed outcomeIndex,
+        uint outcomeTokensBought
+    );
+    event FPMMSell(
+        address indexed seller,
+        uint returnAmount,
+        uint feeAmount,
+        uint indexed outcomeIndex,
+        uint outcomeTokensSold
+    );
+    ConditionalTokens internal conditionalTokens;
+    IERC20 internal collateralToken;
+    bytes32[] internal conditionIds;
+    uint internal fee;
+    uint internal feePoolWeight;
+
+    uint[] internal outcomeSlotCounts;
+    bytes32[][] internal collectionIds;
+    uint[] internal positionIds;
+    mapping (address => uint256) internal withdrawnFees;
+    uint internal totalWithdrawnFees;
+}

--- a/contracts/FixedProductMarketMakerFactory.sol
+++ b/contracts/FixedProductMarketMakerFactory.sol
@@ -20,7 +20,6 @@ contract FixedProductMarketMakerData {
     event FPMMFundingAdded(
         address indexed funder,
         uint[] amountsAdded,
-        uint collateralAddedToFeePool,
         uint sharesMinted
     );
     event FPMMFundingRemoved(
@@ -52,6 +51,8 @@ contract FixedProductMarketMakerData {
     uint[] internal outcomeSlotCounts;
     bytes32[][] internal collectionIds;
     uint[] internal positionIds;
+    mapping (address => uint256) internal withdrawnFees;
+    uint internal totalWithdrawnFees;
 }
 
 contract FixedProductMarketMakerFactory is ConstructedCloneFactory, FixedProductMarketMakerData {

--- a/contracts/FixedProductMarketMakerFactory.sol
+++ b/contracts/FixedProductMarketMakerFactory.sol
@@ -47,6 +47,7 @@ contract FixedProductMarketMakerData {
     IERC20 internal collateralToken;
     bytes32[] internal conditionIds;
     uint internal fee;
+    uint internal collectedFees;
 
     uint[] internal outcomeSlotCounts;
     bytes32[][] internal collectionIds;

--- a/contracts/FixedProductMarketMakerFactory.sol
+++ b/contracts/FixedProductMarketMakerFactory.sol
@@ -4,56 +4,9 @@ import { IERC20 } from "openzeppelin-solidity/contracts/token/ERC20/IERC20.sol";
 import { ConditionalTokens } from "@gnosis.pm/conditional-tokens-contracts/contracts/ConditionalTokens.sol";
 import { CTHelpers } from "@gnosis.pm/conditional-tokens-contracts/contracts/CTHelpers.sol";
 import { ConstructedCloneFactory } from "@gnosis.pm/util-contracts/contracts/ConstructedCloneFactory.sol";
-import { FixedProductMarketMaker } from "./FixedProductMarketMaker.sol";
+import { FixedProductMarketMaker, FixedProductMarketMakerData } from "./FixedProductMarketMaker.sol";
 import { ERC1155TokenReceiver } from "@gnosis.pm/conditional-tokens-contracts/contracts/ERC1155/ERC1155TokenReceiver.sol";
 
-contract FixedProductMarketMakerData {
-    mapping (address => uint256) internal _balances;
-    mapping (address => mapping (address => uint256)) internal _allowances;
-    uint256 internal _totalSupply;
-
-
-    bytes4 internal constant _INTERFACE_ID_ERC165 = 0x01ffc9a7;
-    mapping(bytes4 => bool) internal _supportedInterfaces;
-
-
-    event FPMMFundingAdded(
-        address indexed funder,
-        uint[] amountsAdded,
-        uint sharesMinted
-    );
-    event FPMMFundingRemoved(
-        address indexed funder,
-        uint[] amountsRemoved,
-        uint collateralRemovedFromFeePool,
-        uint sharesBurnt
-    );
-    event FPMMBuy(
-        address indexed buyer,
-        uint investmentAmount,
-        uint feeAmount,
-        uint indexed outcomeIndex,
-        uint outcomeTokensBought
-    );
-    event FPMMSell(
-        address indexed seller,
-        uint returnAmount,
-        uint feeAmount,
-        uint indexed outcomeIndex,
-        uint outcomeTokensSold
-    );
-    ConditionalTokens internal conditionalTokens;
-    IERC20 internal collateralToken;
-    bytes32[] internal conditionIds;
-    uint internal fee;
-    uint internal collectedFees;
-
-    uint[] internal outcomeSlotCounts;
-    bytes32[][] internal collectionIds;
-    uint[] internal positionIds;
-    mapping (address => uint256) internal withdrawnFees;
-    uint internal totalWithdrawnFees;
-}
 
 contract FixedProductMarketMakerFactory is ConstructedCloneFactory, FixedProductMarketMakerData {
     event FixedProductMarketMakerCreation(


### PR DESCRIPTION
I've added a separate storage value for tracking the amount `collectedFees`. This prevents griefers from directly setting the fee pool proportion by transferring collateral to the market maker.

I've also changed `removeFunding` and `addFunding` to use `ceildiv` in a couple of places. The `ceildiv` in `removeFunding` has the effect of ensuring the fee pool proportion rounds down as funding gets removed/granularity of market maker pools decreases. This prevents first funders from setting the fee pool proportion unusually high by burning their pool tokens down to 1 unit. The other `ceildiv` makes sure enough of a proportion of collateral during `addFunding` makes it into the fee pool such that immediately burning the pool tokens generated from `addFunding` would not leech units of collateral off of the market maker.

Originally, I had thought of a mitigation tactic for this latter griefing scenario involving increasing the granularity of `collectedFees`, but this turns out to be problematic. The natural choice (reusing 10**18 as ONE) does something similar to the tactic that was settled on, though some proportion was conserved. It became more difficult to balance this also with the pool values, which aren't fixed point and do get "reset" by the burn-to-one-wei attack. Generally, the fee pool proportion would decrease in that scenario somewhat. After introducing a separate fixed point ONE choice for the `collectedFees`, I noticed that that the fee pool proportion would get more and more accurately preserved the more ONE gets increased, but at the cost of some room for values, and also it would depend on the choice of the fixed point, as well as the "decimals" of the collateral. While it's probably okay to assume that collateral tokens will have 18 decimals, if the ONE choice is too small compared to typical collateral token amounts, it will actually revert back to rounding up the fee pool proportion. In this case, it can only be raised to the next "level" of fee pool granularity, so the attack has been limited, but at this point the code got way harder to read/write, and I ended up using some ceildivs to try and rectify that situation as well. Mixing ceildivs and an increase of granularity caused the code to lose the higher accuracy gains from pushing up the granularity of `collectedFees` somehow, so I finally scrapped everything and just went with the approach described above. Anyway, TL;DR: didn't increase `collectedFees` granularity because it got too complicated.